### PR TITLE
Adds test cases for roundtrip encode-decode of slices & maps

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/fxamacker/cbor/v2"
 )
 
+func nilPointerFor[T interface{}]() *T {
+	return nil
+}
+
 func TestRoundtrip(t *testing.T) {
 	type modePair struct {
 		enc cbor.EncMode
@@ -52,6 +56,14 @@ func TestRoundtrip(t *testing.T) {
 		{
 			name: "empty map",
 			obj:  map[string]interface{}{},
+		},
+		{
+			name: "nil pointer to slice",
+			obj:  nilPointerFor[[]interface{}](),
+		},
+		{
+			name: "nil pointer to map",
+			obj:  nilPointerFor[map[string]interface{}](),
 		},
 		{
 			name: "nonempty string",
@@ -125,6 +137,30 @@ func TestRoundtrip(t *testing.T) {
 			name: "nil pointer omitempty",
 			obj: struct {
 				V *struct{} `json:"v,omitempty"`
+			}{},
+		},
+		{
+			name: "nil pointer to slice as struct field",
+			obj: struct {
+				V *[]interface{} `json:"v"`
+			}{},
+		},
+		{
+			name: "nil pointer to slice as struct field with omitempty",
+			obj: struct {
+				V *[]interface{} `json:"v,omitempty"`
+			}{},
+		},
+		{
+			name: "nil pointer to map as struct field",
+			obj: struct {
+				V *map[string]interface{} `json:"v"`
+			}{},
+		},
+		{
+			name: "nil pointer to map as struct field with omitempty",
+			obj: struct {
+				V *map[string]interface{} `json:"v,omitempty"`
 			}{},
 		},
 	} {


### PR DESCRIPTION
Following testcases are added:
1. Absent (uninitialized) slice and map
2. nil pointer to a slice and a map
3. nil pointer to a slice and a map as struct fields each with and without omitempty tag

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->